### PR TITLE
Updated depcrecated MediaStream.stop()

### DIFF
--- a/simple-demos/audio-recording.html
+++ b/simple-demos/audio-recording.html
@@ -180,7 +180,7 @@ btnReleaseMicrophone.onclick = function() {
     btnStartRecording.disabled = false;
 
     if(microphone) {
-        microphone.stop();
+        microphone.getTracks().forEach( t => t.stop());();
         microphone = null;
     }
 


### PR DESCRIPTION
I experienced the same problem described in: 
https://stackoverflow.com/questions/34966809/stop-kill-webrtc-media-stream.

According to https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API, MediaStream.stop() is deprecated.

This commit changes .stop() to .getTracks().forEach( t => t.stop());